### PR TITLE
Add vetos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 WebSocket relay for Neotokyo and a spectator overlay client.
 
 ## Dependencies
-https://github.com/peace-maker/sm-websocket
+* https://github.com/peace-maker/sm-websocket
+* [nt_competitive_vetos_enum.inc and nt_competitive_vetos_natives.inc](https://github.com/Rainyan/sourcemod-nt-competitive-vetos/tree/main/scripting/include) include files

--- a/scripting/nt_websocket.sp
+++ b/scripting/nt_websocket.sp
@@ -172,14 +172,14 @@ public void OnMapVetoStageUpdate(VetoStage new_veto_stage, int param2)
 		}
 	}
 
-	char sBuffer[128];
+	char sBuffer[7];
 	Format(sBuffer, sizeof(sBuffer), "Y%d:%d", new_veto_stage, param2);
 	SendToAllChildren(sBuffer);
 }
 
 public void OnMapVetoPick(VetoStage current_veto_stage, int vetoing_team, const char[] map_name)
 {
-	char sBuffer[128];
+	char sBuffer[6 + PLATFORM_MAX_PATH + 1];
 	Format(sBuffer, sizeof(sBuffer), "Z%d:%d:%s", current_veto_stage, vetoing_team, map_name);
 	SendToAllChildren(sBuffer);
 }

--- a/scripting/nt_websocket.sp
+++ b/scripting/nt_websocket.sp
@@ -190,7 +190,7 @@ public Action OnSetObserver(int client, int args)
 	g_currentObserver = client;
 	CreateTimer(0.1, CheckObserverTarget, _, TIMER_REPEAT);
 
-	PrintToConsole(client, "Tracking observer target for %N", client);
+	ReplyToCommand(client, "You are now set as the stream observer.");
 
 	return Plugin_Handled;
 }

--- a/scripting/nt_websocket.sp
+++ b/scripting/nt_websocket.sp
@@ -15,6 +15,8 @@
 
 // Separate XP, frags and assists? Might be hard to keep in sync with the comp plugin shenanigans.
 
+// Map vetos
+
 // Track shooting players
 
 // Players "spawning" mid round, usually after switching team, are reported as alive even if they're dead.

--- a/scripting/nt_websocket.sp
+++ b/scripting/nt_websocket.sp
@@ -157,16 +157,14 @@ public void OnMapVetoStageUpdate(VetoStage new_veto_stage, int param2)
 	if (new_veto_stage == VETO_STAGE_COIN_FLIP) {
 		int veto_pool_size = CompetitiveVetos_GetVetoMapPoolSize();
 		if (veto_pool_size > 0) {
-			int size = veto_pool_size * PLATFORM_MAX_PATH + veto_pool_size + 1;
-			char[] vetoListBuff = new char[size];
-			int num_written = Format(vetoListBuff, size, "L%d:", veto_pool_size);
-			if (veto_pool_size > 0) {
-				char map_name[PLATFORM_MAX_PATH];
-				for (int i = 0; i < veto_pool_size; ++i) {
-					if (CompetitiveVetos_GetNameOfMapPoolMap(i, map_name, sizeof(map_name)) != 0) {
-						num_written += StrCat(vetoListBuff, size, map_name);
-						num_written += StrCat(vetoListBuff, size, ":");
-					}
+			int buff_size = veto_pool_size * PLATFORM_MAX_PATH + veto_pool_size + 1;
+			char[] vetoListBuff = new char[buff_size];
+			int num_written = Format(vetoListBuff, buff_size, "L%d:", veto_pool_size);
+			char map_name[PLATFORM_MAX_PATH];
+			for (int i = 0; i < veto_pool_size; ++i) {
+				if (CompetitiveVetos_GetNameOfMapPoolMap(i, map_name, sizeof(map_name)) != 0) {
+					num_written += StrCat(vetoListBuff, buff_size, map_name);
+					num_written += StrCat(vetoListBuff, buff_size, ":");
 				}
 			}
 			vetoListBuff[num_written - 1] = '\0'; // Remove trailing delimiter

--- a/scripting/nt_websocket.sp
+++ b/scripting/nt_websocket.sp
@@ -59,7 +59,7 @@
 #include <nt_competitive_vetos_enum>
 #include <nt_competitive_vetos_natives>
 
-#define PLUGIN_VERSION "1.3.1"
+#define PLUGIN_VERSION "1.3.2"
 
 #define NEO_MAX_CLIENTS 32
 
@@ -106,6 +106,7 @@ public OnPluginStart()
 	g_hostname = FindConVar("hostname");
 
 	RegConsoleCmd("sm_setobserver", OnSetObserver, "Set current observer for spectator overlay");
+	RegConsoleCmd("sm_setobserve", OnSetObserver, "Alias for sm_setobserver");
 #if NT_RELAY_DEBUG
 	RegConsoleCmd("sm_relaydbg", OnRelayDebug, "Send fake relay output for debugging purposes");
 	RegConsoleCmd("sm_relaydbg_populate", OnRelayWepsDebug, "Populate the server relay with fake players. Optionally, pass in the number of fake players wanted.");

--- a/spec-client/src/store.js
+++ b/spec-client/src/store.js
@@ -155,6 +155,17 @@ async function handleMessage(data) {
 
             break;
         }
+        // * L: List of veto maps that are used for vetos
+        case 'L': {
+            const num_maps = parts[0];
+            let maps = [];
+            for (let i = 1; i <= num_maps; ++i) {
+                maps.push(parts[i]);
+            }
+            console.log('L -- Maps:\n' + maps);
+
+            break;
+        }
         // * N: Player changed his name
         case 'N': {
             const player = uidToPlayer[parts[0]];
@@ -244,22 +255,27 @@ async function handleMessage(data) {
             break;
         }
 
-        /* Example output from the Y and Z messages for a full veto:
+		/* Example output from the veto flow:
 
-            Y -- Stage: CoinFlip
-            Y -- Stage: CoinFlipResult && Team: NSF
-            Z -- Stage: FirstTeamBan && Team: NSF && Map: nt_ghost_ctg
-            Y -- Stage: FirstTeamBan
-            Z -- Stage: SecondTeamBan && Team: Jinrai && Map: nt_sentinel_ctg
-            Y -- Stage: SecondTeamBan
-            Z -- Stage: SecondTeamPick && Team: Jinrai && Map: nt_dusk_ctg
-            Y -- Stage: SecondTeamPick
-            Z -- Stage: FirstTeamPick && Team: NSF && Map: nt_threadplate_ctg
-            Y -- Stage: FirstTeamPick
-            Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_skyline_ctg
-            Y -- Stage: RandomThirdMap
-            Y -- Stage: Inactive
-        */
+			L -- Maps:
+					array of [nt_ballistrade_ctg,nt_bullet_tdm,nt_dawn_ctg,
+							  nt_decom_ctg,nt_disengage_ctg,nt_dusk_ctg,
+							  nt_engage_ctg,nt_ghost_ctg,nt_isolation_ctg]
+			Y -- Stage: CoinFlip
+			Y -- Stage: CoinFlipResult && Team: Jinrai
+			Z -- Stage: FirstTeamBan && Team: Jinrai && Map: nt_dusk_ctg
+			Y -- Stage: FirstTeamBan
+			Z -- Stage: SecondTeamBan && Team: NSF && Map: nt_dawn_ctg
+			Y -- Stage: SecondTeamBan
+			Z -- Stage: SecondTeamPick && Team: NSF && Map: nt_decom_ctg
+			Y -- Stage: SecondTeamPick
+			Z -- Stage: FirstTeamPick && Team: Jinrai && Map: nt_isolation_ctg
+			Y -- Stage: FirstTeamPick
+			Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_ghost_ctg
+			Y -- Stage: RandomThirdMap
+			Y -- Stage: Inactive
+
+		*/
     }
 
     // console.log(data);

--- a/spec-client/src/store.js
+++ b/spec-client/src/store.js
@@ -14,6 +14,16 @@ const CLASSES = [
     "Support",
 ]
 
+const VETOSTAGES = [
+    "Inactive",
+    "CoinFlip",
+    "FirstTeamBan",
+    "SecondTeamBan",
+    "SecondTeamPick",
+    "FirstTeamPick",
+    "RandomThirdMap",
+]
+
 const store = reactive({
     players: [],
     roundNumber: 0,
@@ -206,6 +216,42 @@ async function handleMessage(data) {
 
             break;
         }
+        // Y: VetoStage has changed
+        case 'Y': {
+            const stage = VETOSTAGES[parts[0]];
+            // TODO: if VETOSTAGES.Inactive, hide any veto visual we've got.
+            //       else, display veto stage visuals as appropriate.
+            console.log('Y -- Stage: ' + stage);
+
+            break;
+        }
+        // Z: A veto map ban/pick has been decided
+        case 'Z': {
+            const stage = VETOSTAGES[parts[0]];
+            const team =  TEAMS[parts[1]];
+            const mapName = parts[2];
+            // TODO: Display the ban/pick visuals.
+            console.log('Z -- Stage: ' + stage + ' && Team: ' + team + ' && Map: ' + mapName);
+
+            break;
+        }
+
+        /* Example output from the Y and Z messages for a full veto:
+
+            Y -- Stage: CoinFlip
+            Z -- Stage: FirstTeamBan && Team: Jinrai && Map: nt_dawn_ctg
+            Y -- Stage: FirstTeamBan
+            Z -- Stage: SecondTeamBan && Team: NSF && Map: nt_disengage_ctg
+            Y -- Stage: SecondTeamBan
+            Z -- Stage: SecondTeamPick && Team: NSF && Map: nt_oilstain_ctg
+            Y -- Stage: SecondTeamPick
+            Z -- Stage: FirstTeamPick && Team: Jinrai && Map: nt_isolation_ctg
+            Y -- Stage: FirstTeamPick
+            Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_pissalley_ctg
+            Y -- Stage: RandomThirdMap
+            Y -- Stage: Inactive
+
+        */
     }
 
     // console.log(data);

--- a/spec-client/src/store.js
+++ b/spec-client/src/store.js
@@ -37,18 +37,18 @@ const store = reactive({
 const uidToPlayer = {};
 
 function debounce(func, wait, immediate) {
-	var timeout;
-	return function() {
-		var context = this, args = arguments;
-		var later = function() {
-			timeout = null;
-			if (!immediate) func.apply(context, args);
-		};
-		var callNow = immediate && !timeout;
-		clearTimeout(timeout);
-		timeout = setTimeout(later, wait);
-		if (callNow) func.apply(context, args);
-	};
+    var timeout;
+    return function() {
+        var context = this, args = arguments;
+        var later = function() {
+            timeout = null;
+            if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+    };
 }
 
 async function getAvatarURLs(players) {

--- a/spec-client/src/store.js
+++ b/spec-client/src/store.js
@@ -22,6 +22,7 @@ const VETOSTAGES = [
     "SecondTeamPick",
     "FirstTeamPick",
     "RandomThirdMap",
+    "CoinFlipResult",
 ]
 
 const store = reactive({
@@ -219,9 +220,16 @@ async function handleMessage(data) {
         // Y: VetoStage has changed
         case 'Y': {
             const stage = VETOSTAGES[parts[0]];
-            // TODO: if VETOSTAGES.Inactive, hide any veto visual we've got.
+
+            if (stage == "CoinFlipResult") {
+                const team = TEAMS[parts[1]];
+                console.log('Y -- Stage: ' + stage + ' && Team: ' + team);
+            }
+            else {
+                console.log('Y -- Stage: ' + stage);
+            }
+            // TODO: if stage == VETOSTAGES.Inactive, hide any veto visual we've got.
             //       else, display veto stage visuals as appropriate.
-            console.log('Y -- Stage: ' + stage);
 
             break;
         }
@@ -239,18 +247,18 @@ async function handleMessage(data) {
         /* Example output from the Y and Z messages for a full veto:
 
             Y -- Stage: CoinFlip
-            Z -- Stage: FirstTeamBan && Team: Jinrai && Map: nt_dawn_ctg
+            Y -- Stage: CoinFlipResult && Team: NSF
+            Z -- Stage: FirstTeamBan && Team: NSF && Map: nt_ghost_ctg
             Y -- Stage: FirstTeamBan
-            Z -- Stage: SecondTeamBan && Team: NSF && Map: nt_disengage_ctg
+            Z -- Stage: SecondTeamBan && Team: Jinrai && Map: nt_sentinel_ctg
             Y -- Stage: SecondTeamBan
-            Z -- Stage: SecondTeamPick && Team: NSF && Map: nt_oilstain_ctg
+            Z -- Stage: SecondTeamPick && Team: Jinrai && Map: nt_dusk_ctg
             Y -- Stage: SecondTeamPick
-            Z -- Stage: FirstTeamPick && Team: Jinrai && Map: nt_isolation_ctg
+            Z -- Stage: FirstTeamPick && Team: NSF && Map: nt_threadplate_ctg
             Y -- Stage: FirstTeamPick
-            Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_pissalley_ctg
+            Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_skyline_ctg
             Y -- Stage: RandomThirdMap
             Y -- Stage: Inactive
-
         */
     }
 


### PR DESCRIPTION
TLDR: ~~This PR isn't really ready to be merged as-is~~ (actual spec-client veto visuals are missing), but could work a starting point for implementing vetos to the overlay.

This PR adds support for accessing the vetos information from spec-client, by using the SM global forwards provided by the [nt_competitive_vetos](https://github.com/Rainyan/sourcemod-nt-competitive-vetos) plugin.

This change adds [these two includes](https://github.com/Rainyan/sourcemod-nt-competitive-vetos/tree/main/scripting/include) as compile dependencies for the nt_websocket plugin. However, nt_websocket binary will continue to work even without the veto plugin present, as it's just listening for the global forwards regardless of if they actually exist or not.

### What works:
* nt_websocket listens for the global forwards _OnMapVetoStageUpdate(...)_ and _OnMapVetoPick(...)_, and sends that data through the websocket using the unoccupied 'Y' and 'Z' control chars.
* spec-client receives that data in _async function handleMessage(...)_, and console.log's it, with output something like:
```
Y -- Stage: CoinFlip // Coin flip begins
Y -- Stage: CoinFlipResult && Team: NSF // NSF wins coin flip
Z -- Stage: FirstTeamBan && Team: NSF && Map: nt_ghost_ctg // NSF bans ghost
Y -- Stage: FirstTeamBan
Z -- Stage: SecondTeamBan && Team: Jinrai && Map: nt_sentinel_ctg // Jinrai bans sentinel
Y -- Stage: SecondTeamBan
Z -- Stage: SecondTeamPick && Team: Jinrai && Map: nt_dusk_ctg // Jinrai picks dusk
Y -- Stage: SecondTeamPick
Z -- Stage: FirstTeamPick && Team: NSF && Map: nt_threadplate_ctg // NSF picks threadplate
Y -- Stage: FirstTeamPick
Z -- Stage: RandomThirdMap && Team: Spectator && Map: nt_skyline_ctg // Random map is skyline
Y -- Stage: RandomThirdMap
Y -- Stage: Inactive // Veto is over
```

### What doesn't work:
* There's no visual indication whatsoever in the spec-client for these vetos. All it does it console.log().

### Setting up fake the players & veto activity for testing:
* Set the `NT_RELAY_DEBUG` define in nt_websocket.sp to true. This compiles in the "sm_relaydbg_populate" debug command, which adds 10 fake clients to the spec-client view, so one can approximate how it would look on an actual server.
* Un-comment the `#define DEBUG_FAKE_VETOS` define in nt_competitive_vetos.sp. This compiles in the "sm_debug_fake_veto" debug command, which will play back a random fake veto process, resulting in spec-client input similar to what was described in those console.log lines above.

I'm not too familiar with Vue.js, so maybe I should leave that up to you to decide how to visually represent? Could probably mimic the visual imagery of vetos in other comp games/streams.